### PR TITLE
phpdotenv removed from composer.js

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
   "type": "library",
   "require": {
     "php": ">=7.1",
-    "activecampaign/api-php": "^2.0",
-    "vlucas/phpdotenv": "^2.5"
+    "activecampaign/api-php": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "6.*"


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--You also read mall from https://github.com/kudobuzz/guides/edit/master/code-review-guidelines.md-->

- [x] Your pull request targets the `stage` branch of seodoctor-autofix.
- [x] Branch name is descriptive. 
- [x] All new and existing tests pass the command `npm phpunit`. 

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.

#### What does this pr do?
phpdotenv removed from composer.js. When installing codeception requires "vlucas/phpdotenv": "^3.0" which is causing conflict.  

#### What are the relevant issues?
https://github.com/kudobuzz/seodoctor-merchant-dashboard/issues/1558

